### PR TITLE
Add Jest, Add Plain Chars tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,14 +5,16 @@
   "main": "lib/index.js",
   "contributors": [
     "Desiderio Silva <desideriotbs@gmail.com> (https://github.com/dsilva01)"
- ],
+  ],
   "directories": {
     "example": "example"
   },
   "dependencies": {
     "vowels": "^1.0.0"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "jest": "^29.1.2"
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/tests/PlainCharacters.test.js
+++ b/tests/PlainCharacters.test.js
@@ -1,0 +1,33 @@
+const IsVowel = require('../lib/index');
+
+test("Unaccented vowels return true.", () => {
+    expect(IsVowel("a")).toBe(true);
+    expect(IsVowel("e")).toBe(true);
+    expect(IsVowel("i")).toBe(true);
+    expect(IsVowel("o")).toBe(true);
+    expect(IsVowel("u")).toBe(true);
+});
+
+test("Unaccented not-vowels return false.", () => {
+    expect(IsVowel("b")).toBe(false);
+    expect(IsVowel("c")).toBe(false);
+    expect(IsVowel("d")).toBe(false);
+    expect(IsVowel("f")).toBe(false);
+    expect(IsVowel("g")).toBe(false);
+    expect(IsVowel("h")).toBe(false);
+    expect(IsVowel("j")).toBe(false);
+    expect(IsVowel("k")).toBe(false);
+    expect(IsVowel("l")).toBe(false);
+    expect(IsVowel("m")).toBe(false);
+    expect(IsVowel("n")).toBe(false);
+    expect(IsVowel("p")).toBe(false);
+    expect(IsVowel("q")).toBe(false);
+    expect(IsVowel("r")).toBe(false);
+    expect(IsVowel("s")).toBe(false);
+    expect(IsVowel("t")).toBe(false);
+    expect(IsVowel("v")).toBe(false);
+    expect(IsVowel("w")).toBe(false);
+    expect(IsVowel("x")).toBe(false);
+    expect(IsVowel("y")).toBe(false);
+    expect(IsVowel("z")).toBe(false);
+});


### PR DESCRIPTION
Heyo, here for Hacktoberfest contribution. Planning on a one-two contribution here -- tests, then automated running of those tests once this PR is approved.

This PR will add:

- Jest as a dev dependency to the project
- Two Jest tests
    - One for expected behaviours when given aeiou
    - One for expected behaviours when given consonants 

Not worrying about accented characters here -- that can be for others to PR for their own Hacktoberfest contributions ;) 